### PR TITLE
[EOSF-441] Order via Date Published, add withdrawn label, fix type ordering.

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -39,14 +39,14 @@ export default Ember.Controller.extend(Analytics, RegistrationCount, {
     ],
 
     registrationTypes: [
-        'Prereg Challenge',
-        'Open-Ended Registration',
         'AsPredicted Preregistration',
+        'Election Research Preacceptance Competition',
+        'Open-Ended Registration',
         'OSF-Standard Pre-Data Collection Registration',
-        'Replication Recipe (Brandt et al., 2013): Pre-Registration',
-        'Replication Recipe (Brandt et al., 2013): Post-Completion',
+        'Prereg Challenge',
         'Pre-Registration in Social Psychology (van \'t Veer & Giner-Sorolla, 2016): Pre-Registration',
-        'Election Research Preacceptance Competition'
+        'Replication Recipe (Brandt et al., 2013): Post-Completion',
+        'Replication Recipe (Brandt et al., 2013): Pre-Registration',
     ],
 
     page: 1,
@@ -295,9 +295,9 @@ export default Ember.Controller.extend(Analytics, RegistrationCount, {
         const sort = {};
 
         if (sortByOption === 'Upload date (oldest to newest)') {
-            sort.date_updated = 'asc';
+            sort.date_published = 'asc';
         } else if (sortByOption === 'Upload date (newest to oldest)') {
-            sort.date_updated = 'desc';
+            sort.date_published = 'desc';
         }
 
         return this.set('queryBody', {

--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -7,7 +7,10 @@
                     {{#if hyperlink}}
                         <a href='{{hyperlink}}' {{action 'click' 'link' 'Registries - Discover - Result Title' hyperlink}}>{{result.title}}</a>
                     {{else}}
-                        <span>{{result.title}}</span>
+                        <span>{{result.title}} </span>
+                    {{/if}}
+                    {{#if result.withdrawn}}
+                        <span class='label label-default'> Withdrawn </span>
                     {{/if}}
                 </h4>
                 {{!Authors}}
@@ -42,8 +45,8 @@
                         {{/if}}
                     </span>
                     <span class="pull-right">
-                        {{#if result.date_created}} {{! moment-format will use current time if null}}
-                            <span>{{moment-format result.date_created "MMMM YYYY"}}</span>
+                        {{#if result.date_published}} {{! moment-format will use current time if null}}
+                            <span>{{moment-format result.date_published "MMMM YYYY"}}</span>
                         {{/if}}
                     </span>
                 </div>

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "0.2.0",
+    "ember-osf": "0.2.1",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2119,9 +2119,9 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-osf@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.2.0.tgz#7b3ab441d6d66059b0c503fe5db4c5e564077b54"
+ember-osf@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.2.1.tgz#da0e49b6eea941aef5e48b044665430995215985"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"


### PR DESCRIPTION

## Purpose
Fix registries discover ordering, add withdrawal label, fix ordering of registration types.

## Changes
 - Registration Types are now sorted alphabetically
 - Addition of withdrawn label:
![screen shot 2017-02-22 at 3 11 57 pm](https://cloud.githubusercontent.com/assets/6268982/23230733/19c94934-f913-11e6-815f-98b6770c43c1.png)
 - Label on bottom right that indicates date now indicates date published instead of date created (i.e. added to share). 
 - Date ordering now does so based on publication date instead of date updated.


## Side effects
Potential different date sorted order compared to SHARE page with similar (registries) filters.

## Ticket

https://openscience.atlassian.net/browse/EOSF-441
