### PR TITLE
[EOSF-534] Hide random hour of the day timestamp on Registries

### DIFF
--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -76,7 +76,7 @@
                         </div>
                     {{/if}}
                     {{!Added on}}
-                    <div class="m-t-sm"> {{t "global.added_on"}}: {{moment-format result.date_created}} </div>
+                    <div class="m-t-sm"> {{t "global.added_on"}}: {{moment-format result.date_created "YYYY-MM-DD"}} </div>
                 {{/if}}
 
             </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

SHARE isn't able to get a timestamp from most providers, which means that some of the timestamps in Ember Preprints and Registries are randomly assigned. The purpose of this ticket is to remove the time portion of the timestamp from Preprints.

## Changes

Changes for this ticket include changing the format of the timestamp to only be in "YYYY-MM-DD" format, leaving out the time.

## Screenshots

Originally, the 'Added on' date for registries would show the time it was added with the date.
<img width="1440" alt="screen shot 2017-03-10 at 12 01 17 pm" src="https://cloud.githubusercontent.com/assets/19379783/23806011/0dad2a94-058e-11e7-8d4d-c4218e4dbe95.png">

<br>
After being removed, the 'Added on' date shows only the date without the time.
<img width="1440" alt="screen shot 2017-03-10 at 12 27 26 pm" src="https://cloud.githubusercontent.com/assets/19379783/23806015/13851c9c-058e-11e7-9944-e4597ca961a5.png">


## Ticket

https://openscience.atlassian.net/browse/EOSF-534