### PR TITLE
Feature/System Variables for Ember-Metrics Environment [EOSF-571]

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -54,14 +54,14 @@ module.exports = function(environment) {
         metricsAdapters: [
             {
                 name: 'GoogleAnalytics',
-                environments: ['production'],
+                environments: [process.env.KEEN_ENVIRONMENT] || ['production'],
                 config: {
                     id: process.env.GOOGLE_ANALYTICS_ID
                 }
             },
             {
                 name: 'Keen',
-                environments: ['production'],
+                environments: [process.env.KEEN_ENVIRONMENT] || ['production'],
                 config: {
                     private: {
                         projectId: process.env.REGISTRIES_PRIVATE_PROJECT_ID,


### PR DESCRIPTION
## Purpose

In [Ember-Metrics](https://github.com/poteto/ember-metrics), which we use to send Analytics to both Keen, and Google Analytics, you can specify which environments will send analytics to Keen/GA.  
> To only activate adapters in specific environments, you can add an array of environment names to the config, as the environments key. Valid environments are:
> 
> * development
> * test,
> * production
> * all (default, will be activated in all environments)

Default is currently "production" so analytics will not be fired locally unless you manually change this.   Adds system variables to help deployment - different configurations for staging/production.

## Changes

Changes ['production'] for the environment for both Keen/GA to `[process.env.KEEN_ENVIRONMENT] || ['production']`.

## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/EOSF-571