### PR TITLE
[EOSF-596] Update signup and redirect urls and disable campaign

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -5,6 +5,7 @@ const Router = Ember.Router.extend({
     location: config.locationType,
     rootURL: config.rootURL,
     metrics: Ember.inject.service(),
+    theme: Ember.inject.service(),
 
     didTransition() {
         this._super(...arguments);
@@ -17,6 +18,7 @@ const Router = Ember.Router.extend({
             const title = this.getWithDefault('currentRouteName', 'unknown');
 
             Ember.get(this, 'metrics').trackPage({ page, title });
+            this.set('theme.currentLocation', window.location.href);
         });
     }
 });

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -7,6 +7,8 @@ export default Ember.Service.extend({
 
     id: config.REGISTRIES.defaultProvider,
 
+    currentLocation: null,
+
     provider: Ember.computed('id', function() {
         const id = this.get('id');
 
@@ -45,16 +47,17 @@ export default Ember.Service.extend({
         return logo;
     }),
 
-    signupUrl: Ember.computed('id', function() {
+    signupUrl: Ember.computed('id', 'currentLocation', function() {
         const query = Ember.$.param({
-            campaign: `${this.get('id')}-registries`,
-            next: window.location.href
+            // TODO enable once a registries campaign is ready
+            // campaign: `${this.get('id')}-registries`,
+            next: this.get('currentLocation')
         });
 
         return `${config.OSF.url}register?${query}`;
     }),
 
-    redirectUrl: Ember.computed('isProvider', function() {
-        return this.get('isProvider') ? window.location.href : null;
+    redirectUrl: Ember.computed('currentLocation', function() {
+        return this.get('currentLocation');
     }),
 });

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:application', 'Unit | Controller | application', {
   // Specify the other units that are required for this test.
-  needs: ['service:metrics']
+  needs: ['service:metrics', 'service:theme']
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/index-test.js
+++ b/tests/unit/controllers/index-test.js
@@ -2,7 +2,11 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:index', 'Unit | Controller | index', {
     // Specify the other units that are required for this test.
-    needs: ['service:metrics']
+    needs: [
+        'service:metrics',
+        'service:theme',
+        'service:session'
+    ]
 });
 
 // Replace this with your real tests.

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -2,7 +2,10 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:application', 'Unit | Route | application', {
   // Specify the other units that are required for this test.
-    needs: ['service:metrics']
+    needs: [
+        'service:metrics',
+        'service:theme'
+    ]
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/discover-test.js
+++ b/tests/unit/routes/discover-test.js
@@ -2,7 +2,10 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:discover', 'Unit | Route | discover', {
   // Specify the other units that are required for this test.
-    needs: ['service:metrics']
+    needs: [
+        'service:metrics',
+        'service:theme'
+    ]
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/forbidden-test.js
+++ b/tests/unit/routes/forbidden-test.js
@@ -2,7 +2,10 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:forbidden', 'Unit | Route | forbidden', {
   // Specify the other units that are required for this test.
-  needs: ['service:metrics']
+    needs: [
+        'service:metrics',
+        'service:theme'
+    ]
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -2,7 +2,10 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:index', 'Unit | Route | index', {
   // Specify the other units that are required for this test.
-    needs: ['service:metrics']
+    needs: [
+        'service:metrics',
+        'service:theme'
+    ]
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/page-not-found-test.js
+++ b/tests/unit/routes/page-not-found-test.js
@@ -2,7 +2,10 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:page-not-found', 'Unit | Route | page not found', {
   // Specify the other units that are required for this test.
-    needs: ['service:metrics']
+    needs: [
+        'service:metrics',
+        'service:theme'
+    ]
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
## Purpose

When campaign is included, the OSF signup page gives a 400 error, because a registries campaign is not yet available

## Changes

Commented out the campaign query param so that it won't get passed to the url, and used the current location for next url and redirect url for sign up / sign in, respectively.

## Ticket

https://openscience.atlassian.net/browse/EOSF-596
