### PR TITLE
Pin to ember-osf 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#2c9a020d146534a12011cc920107380c58397f04",
+    "ember-osf": "0.5.0",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,9 +2470,9 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-"ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#2c9a020d146534a12011cc920107380c58397f04":
-  version "0.4.0"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#2c9a020d146534a12011cc920107380c58397f04"
+ember-osf@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.5.0.tgz#849d804644546cfded596311f688dd10855688cf"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"


### PR DESCRIPTION
## Purpose

Pin to ember-osf 0.5.0

## Changes

1. Pinned to ember-osf 0.5.0 in package.json
1. Updated yarn.lock

## Side effects

None

## Ticket

N/A
