### PR TITLE
[EOSF-684] Use ember-osf 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "^0.5.4",
+    "ember-osf": "0.5.4",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "0.5.0",
+    "ember-osf": "^0.5.4",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,7 +2470,7 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-osf@^0.5.4:
+ember-osf@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.5.4.tgz#04a5a188d9c5ec5aaa9cb582b33cb2fbe2d2efb2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,9 +2470,9 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-osf@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.5.0.tgz#849d804644546cfded596311f688dd10855688cf"
+ember-osf@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.5.4.tgz#04a5a188d9c5ec5aaa9cb582b33cb2fbe2d2efb2"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"


### PR DESCRIPTION
## Purpose

Update ember-osf to 0.5.4

## Changes

Changed package.json to use ember-osf 0.5.4 and regenerated yarn.lock

## Side effects

No more missing translations.

## Ticket

https://openscience.atlassian.net/browse/EOSF-684
