### PR TITLE
Feature/Warning Text Style Change [EOSF-557]

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1165,6 +1165,11 @@ nav.branded-navbar {
     }
 }
 
+.type-selector-warning {
+    color: black;
+    display: none;
+    font-weight: bold;
+}
 
 .listOption.btn-link {
     cursor: pointer;

--- a/app/templates/components/search-facet-registration-type.hbs
+++ b/app/templates/components/search-facet-registration-type.hbs
@@ -1,5 +1,5 @@
 <div class="registration-type-selector">
-    <i class='type-selector-warning' style='color: red; display: none'>Only available with OSF Registries</i>
+    <i class='type-selector-warning'>Only available with OSF Registries</i>
     <ul class="m-t-sm">
         {{#each registrationTypes as |item|}}
             <li>


### PR DESCRIPTION

## Purpose

Follow-up change for using discover-page widget in registries.  Change warning text to black and font-weight to bold.

## Changes
Before:
<img width="440" alt="screen shot 2017-05-30 at 3 21 16 pm" src="https://cloud.githubusercontent.com/assets/9755598/26600865/ac912c26-454b-11e7-902a-dcd09bc879af.png">

After:
<img width="398" alt="screen shot 2017-05-30 at 1 39 16 pm" src="https://cloud.githubusercontent.com/assets/9755598/26600832/92cab7b2-454b-11e7-9df9-e93cd58b6efe.png">


## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/EOSF-557
