### PR TITLE
Add postinstall node-sass rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "ember build",
     "start": "ember server",
     "test": "yarn run check-style && ember test",
-    "check-style": "eslint ."
+    "check-style": "eslint .",
+    "postinstall": "npm rebuild node-sass"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Purpose

Rebuild node-sass after yarn installs it because https://github.com/sass/node-sass/issues/1804

https://github.com/yarnpkg/yarn/issues/1981 discusses the issue on the yarn side and suggests this as a workaround.

## Changes

Added "npm rebuild node-sass" as a postinstall hook in package.json

## Side effects

Successful builds!

## Ticket

N/A
