### PR TITLE
[EOSF-554] Update to Node.js version 8

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/boron
+8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 install:
 - curl -o- -L https://yarnpkg.com/install.sh | bash
 - export PATH=$HOME/.yarn/bin:$PATH
-- yarn --prefer-offline --pure-lockfile
+- yarn --prefer-offline --pure-lockfile --ignore-engines
 - ./node_modules/bower/bin/bower install --config.interactive=false
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:8
 
 RUN apt-get update \
     && apt-get install -y \
@@ -40,7 +40,7 @@ RUN mkdir -p /code
 WORKDIR /code
 
 COPY ./package.json ./yarn.lock /code/
-RUN yarn --pure-lockfile
+RUN yarn --pure-lockfile --ignore-engines
 
 COPY ./.bowerrc /code/.bowerrc
 COPY ./bower.json /code/bower.json

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
❗️Needs CenterForOpenScience/osf.io#7350

## Ticket
https://openscience.atlassian.net/browse/EOSF-554

# Purpose
Updates Node.js version to 8

# Summary of changes
Remove lts/boron and replace it with 8 everywhere, and add --ignore-engines due to  qunitjs/qunit#1184.

# Testing notes
This should not affect any functionality, normal regression only.
