### PR TITLE
Added script to update to latest ember-osf develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "ember server",
     "test": "yarn run check-style && ember test",
     "check-style": "eslint .",
-    "postinstall": "npm rebuild node-sass"
+    "postinstall": "npm rebuild node-sass",
+    "use-ember-osf-develop": "yarn upgrade @centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#$(date -u +%FT%TZ)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Ticket

N/A

## Purpose

The purpose of this script is to update ember-osf to use the latest commit from the develop branch. It can be run with `yarn use-ember-osf-develop`. The git url in package.json will be tagged with a timestamp, which forces re-resolution of develop to the latest commit on subsequent updates and indicates when ember-osf was last updated to the tip of develop. The resolved url in yarn.lock points to the actual commit.

## Changes

Added a script to update ember-osf to use the latest commit from the develop branch.

## Side effects

None