### PR TITLE
[EOSF-778] Remove banner except on registries landing page

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -13,8 +13,6 @@
 
 {{maintenance-banner}}
 
-{{donate-banner}}
-
 {{outlet}}
 
 {{#if theme.isProvider}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,3 +1,5 @@
+{{donate-banner}}
+
 <div class="preprints-page"> {{!INDEX}}
 
     {{!HEADER}}


### PR DESCRIPTION
## Purpose

The donate banner should not show up except on the landing page.

## Changes

Removed the donate banner from the main application page and moved it to the landing page.