### PR TITLE
[EOSF-667] Update types filter for changes to discover page search

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -37,7 +37,7 @@ export default Ember.Controller.extend(Analytics, {
         OSF: 'OSF Registries',
         'Research Papers in Economics': 'RePEc'
     },
-    lockedParams: {types: 'registration'}, // Parameter names which cannot be changed
+    lockedParams: {types: ['registration']}, // Parameter names which cannot be changed
     page: 1, // Query param
     provider: '', // Query param
     q: '', // Query param

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-22T20:30:26Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-24T15:45:36Z",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-22T20:30:26Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-24T15:45:36Z":
   version "0.9.1"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#a77296c03dad47f5c616f756ce19e8048e5b58c8"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#5a84342146c0b4afa1fe8bfb4d9b113ff094f35b"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

Change the `types` filter to an array object in preparation for changes to the discover page search.

## Changes

Changed `{types: "registration"}` to use an array: `{types: ["registration"]}`

## Side effects

Since this is affecting what's being passed to the elasticsearch filter, please be sure to check that registrations are showing up as usual.

## Ticket

https://openscience.atlassian.net/browse/EOSF-667