### PR TITLE
get the sentryDSN from the ember config

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -64,14 +64,20 @@ module.exports = function(defaults) {
                 enabled: useCdn,
                 content: `
                     <script src="https://cdn.ravenjs.com/3.5.1/ember/raven.min.js"></script>
-                    <script>Raven.config("${config.sentryDSN}", {}).install();</script>`
+                    <script>
+                        var encodedConfig = document.head.querySelector("meta[name$='/config/environment']").content;
+                        var config = JSON.parse(unescape(encodedConfig));
+                        Raven.config(config.sentryDSN, {}).install();
+                    </script>
+                `.trim()
             },
             cdn: {
                 enabled: useCdn,
                 content: `
                     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-                    <script src="//cdnjs.cloudflare.com/ajax/libs/ember.js/2.7.1/ember.prod.js"></script>`
-            }
+                    <script src="//cdnjs.cloudflare.com/ajax/libs/ember.js/2.7.1/ember.prod.js"></script>
+                `.trim()
+            },
         },
         postcssOptions: {
             compile: {


### PR DESCRIPTION
Same change as in CenterForOpenScience/ember-preprints#455