### PR TITLE
[EOSF-736] Update registries to use latest develop over pinned version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "0.10.4",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-26T20:15:18Z",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@0.10.4":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-26T20:15:18Z":
   version "0.10.4"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/ember-osf/-/ember-osf-0.10.4.tgz#5baa59911229d7056d334bfee0e1f62b20992ac7"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#bf962d9f1a7fc4afe4ed00a620045213a05edf3f"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION

## Purpose
Update registries to use latest develop over pinned version

## Ticket

https://openscience.atlassian.net/browse/EOSF-736
