### PR TITLE
[EOSF-736] Update to osf-style@1.5.1

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,6 +1,6 @@
 @import 'bootstrap';
 @import 'ember-power-select';
-@import 'base';
+@import 'osf-style';
 @import 'variables';
 @import 'authors';
 @import 'validated-input';

--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,10 @@
   "dependencies": {
     "ember": "2.7.0",
     "ember-qunit-notifications": "0.1.0",
-    "osf-style": "https://github.com/CenterforOpenScience/osf-style.git#1.3.0",
     "font-awesome": "4.6.3",
     "jquery": "2.2.4",
     "dropzone": "4.3.0",
+    "bootstrap": "3.3.7",
     "bootstrap-sass": "3.3.6",
     "toastr": "2.1.2",
     "hint.css": "2.3.2",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,7 @@
 const fs = require('fs');
 var path = require('path');
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
-
+const Funnel = require('broccoli-funnel');
 const nonCdnEnvironments = ['development', 'test'];
 
 module.exports = function(defaults) {
@@ -55,7 +55,7 @@ module.exports = function(defaults) {
             includePaths: [
                 'node_modules/@centerforopenscience/ember-osf/addon/styles',
                 'bower_components/bootstrap-sass/assets/stylesheets',
-                'bower_components/osf-style/sass',
+                'node_modules/@centerforopenscience/osf-style/sass',
                 'bower_components/hint.css'
             ]
         },
@@ -126,15 +126,7 @@ module.exports = function(defaults) {
     // along with the exports of each module as its value.
 
     // osf-style
-    app.import(path.join(app.bowerDirectory, 'osf-style/vendor/prism/prism.css'));
-    app.import(path.join(app.bowerDirectory, 'osf-style/page.css'));
-    app.import(path.join(app.bowerDirectory, 'osf-style/css/base.css'));
     app.import(path.join(app.bowerDirectory, 'loaders.css/loaders.min.css'));
-
-
-    app.import(path.join(app.bowerDirectory, 'osf-style/img/cos-white2.png'), {
-        destDir: 'img'
-    });
 
     // app.import('bower_components/dropzone/dist/dropzone.js');
     app.import({
@@ -156,5 +148,12 @@ module.exports = function(defaults) {
     // Import component styles from addon
     app.import('vendor/assets/ember-osf.css');
 
-    return app.toTree();
+    const assets = [
+        new Funnel('node_modules/@centerforopenscience/osf-style/img', {
+            srcDir: '/',
+            destDir: 'img',
+        })
+    ];
+
+    return app.toTree(assets);
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-26T20:15:18Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-10-06T20:53:47Z",
+    "@centerforopenscience/osf-style": "1.5.1",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "2.0.1",
@@ -78,7 +79,6 @@
     "phantomjs-prebuilt": "2.1.11",
     "postcss": "5.1.0"
   },
-  "dependencies": {},
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-osf-registries/issues"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-26T20:15:18Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-10-06T20:53:47Z":
   version "0.10.4"
   resolved "https://github.com/CenterForOpenScience/ember-osf.git#bf962d9f1a7fc4afe4ed00a620045213a05edf3f"
   dependencies:
@@ -30,6 +30,10 @@
     js-yaml "3.8.4"
     keen-tracking "1.1.3"
     langs "1.0.2"
+
+"@centerforopenscience/osf-style@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.5.1.tgz#3ea1a0807c02d06d32bf346620a538613880bc59"
 
 JSONStream@^1.0.3:
   version "1.3.1"


### PR DESCRIPTION
## Purpose

Update to latest osf-style which includes fixes to accommodate gravatar image in nav bar

## Changes

* `yarn add @centerforopenscience/osf-style@1.5.1`
* remove osf-style from bower
* refactor to use osf-style from node_modules

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/EOSF-735
