### PR TITLE
[IN-84] Add JavaScript disabled message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `noscript` message if JavaScript is disabled
+
 ### Changed
 - Remove phantomjs dependency and postinstall hook to rebuild node-sass
 - Use COS ember-base image and multi-stage build

--- a/app/index.html
+++ b/app/index.html
@@ -25,6 +25,13 @@
     </script>
   </head>
   <body>
+    <noscript>
+        <p>
+        For full functionality of this site it is necessary to enable JavaScript.
+        Here are the
+            <a href='https://www.enable-javascript.com/' target='_blank'> instructions how to enable JavaScript in your web browser</a>.
+        </p>
+    </noscript>
     {{content-for "body"}}
 
     {{content-for "cdn"}}


### PR DESCRIPTION
## Purpose

If the user does not have JavaScript enabled on their browser, the site is displayed as a blank white page.  This will add an error message on registries with a link that shows how to enable JavaScript to use the site.

## Summary of Changes

- Add `<noscript>` message

![screen shot 2017-12-07 at 2 31 43 pm](https://user-images.githubusercontent.com/19379783/33734860-9b56ca96-db5b-11e7-8411-a8c4deb0ca8d.png)

## Ticket

https://openscience.atlassian.net/browse/IN-84

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
