### PR TITLE
[IN-232][Registries] Update to use latest osf-style with navbar changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `osf-style` to use the latest version with navbar changes
 
 ## [0.6.12] - 2017-02-14
 ### Added

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@centerforopenscience/ember-osf": "0.14.0",
-    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8",
+    "@centerforopenscience/osf-style": "1.7.0",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@centerforopenscience/ember-osf": "0.14.0",
-    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#develop",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@centerforopenscience/ember-osf": "0.14.0",
-    "@centerforopenscience/osf-style": "1.5.1",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#develop",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@
     moment-timezone "^0.5.13"
     toastr "^2.1.2"
 
-"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#develop":
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8":
   version "1.6.0"
   resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,9 +41,9 @@
     moment-timezone "^0.5.13"
     toastr "^2.1.2"
 
-"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8":
-  version "1.6.0"
-  resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
+"@centerforopenscience/osf-style@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.7.0.tgz#0ae3c0eaaca07fcf8bd667a7b3d7aeeb3244564d"
 
 JSONStream@^1.0.3:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,9 +41,9 @@
     moment-timezone "^0.5.13"
     toastr "^2.1.2"
 
-"@centerforopenscience/osf-style@1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.5.1.tgz#3ea1a0807c02d06d32bf346620a538613880bc59"
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#develop":
+  version "1.6.0"
+  resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
 
 JSONStream@^1.0.3:
   version "1.3.1"


### PR DESCRIPTION
## Purpose

New navbar changes have been merged into `osf-style`.  We should update to use the newest version of the navbar.

## Summary of Changes

- Update `osf-style` dependency to point at the latest version

## Side Effects / Testing Notes

Should use the newest navbar with flexbox

## Ticket

https://openscience.atlassian.net/browse/IN-95

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
