### PR TITLE
[IN-159][Registries] Use ember-osf scheduled-banner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- use of ember-osf `scheduled-banner` component
 
 ## [0.6.12] - 2017-02-14
 ### Added

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,4 +1,4 @@
-{{donate-banner}}
+{{scheduled-banner}}
 
 <div class="preprints-page"> {{!INDEX}}
 


### PR DESCRIPTION
## Purpose

Use ember-osf scheduled-banner component

## Summary of Changes

Modify index page to use new ember-osf `scheduled-banner` component in lieu
old `donnate-banner`

## Side Effects / Testing Notes

Nothing special other making sure the banners displays corrently
and are responsive.

## Ticket

[IN-159](https://openscience.atlassian.net/browse/IN-159)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
