### PR TITLE
[IN-90][Registries] Update to fix non-changing search-facet list

### DIFF
--- a/app/components/search-facet-registration-type.js
+++ b/app/components/search-facet-registration-type.js
@@ -1,5 +1,4 @@
 import Component from '@ember/component';
-import { schedule } from '@ember/runloop';
 import { computed } from '@ember/object';
 import $ from 'jquery';
 
@@ -32,11 +31,14 @@ export default Component.extend({
                 this.set('activeFilters.types', $.extend(true, [], this.get('registrationTypeCache')));
                 this.set('registrationTypeCache', null);
             }
-            this.toggleTypeCSS(true);
+            $('.type-selector-warning').hide();
+            $('.registration-type-selector').fadeTo('slow', 1);
+            return false;
         } else {
             this.set('registrationTypeCache', $.extend(true, [], this.get('activeFilters.types')));
-            this.set('activeFilters.types', []);
-            this.toggleTypeCSS(false);
+            $('.type-selector-warning').show();
+            $('.registration-type-selector').fadeTo('slow', 0.5);
+            return true;
         }
     }),
     init() {
@@ -51,24 +53,6 @@ export default Component.extend({
             'Replication Recipe (Brandt et al., 2013): Post-Completion',
             'Replication Recipe (Brandt et al., 2013): Pre-Registration',
         ];
-        schedule('afterRender', () => {
-            if (this.OSFIsSoleProvider()) {
-                return;
-            }
-            this.toggleTypeCSS(false);
-        });
-    },
-    // Disables search-facet-registration-type
-    toggleTypeCSS(show) {
-        if (show) {
-            $('.type-selector-warning').hide();
-            $('.type-checkbox').removeAttr('disabled');
-            $('.registration-type-selector').fadeTo('slow', 1);
-        } else {
-            $('.type-selector-warning').show();
-            $('.type-checkbox').attr('disabled', 'disabled');
-            $('.registration-type-selector').fadeTo('slow', 0.5);
-        }
     },
     OSFIsSoleProvider() {
         let soleProvider = false;

--- a/app/templates/components/search-facet-registration-type.hbs
+++ b/app/templates/components/search-facet-registration-type.hbs
@@ -4,7 +4,7 @@
         {{#each registrationTypes as |item|}}
             <li>
                 <label>
-                    <input class='type-checkbox' type="checkbox" checked="{{if (if-filter item activeFilters.types) 'checked'}}" onclick={{action updateFilters 'types' item}}>
+                    <input class='type-checkbox' type="checkbox" disabled={{setVisibilityOfOSFFilters}} checked="{{if (if-filter item activeFilters.types) 'checked'}}" onclick={{action updateFilters 'types' item}}>
                     {{item}}
                 </label>
             </li>


### PR DESCRIPTION
## Purpose

As part of a fix to remove observers in ember@2.18 update.

Part of the issue of registries filters not updating is that the property isn't being used.  This fix combines two computed properties and uses them in the template to make it dynamically update instead of using an observer.

## Summary of Changes

- Combine `setVisibilityOfOSFFilters` and `toggleTypeCSS` computed properties
- Set `disabled` property on checkbox based on value of `setVisibilityOfOSFFilters`

## Side Effects / Testing Notes

This should fix the current issue of registration types not updating based on the provider chosen.

If OSF is the chosen provider, the list should be clickable.  If the provider is not OSF, or is a combination of OSF and another provider, the checkboxes are disabled and not able to be clicked.

![jdud7nvdgi](https://user-images.githubusercontent.com/19379783/39323385-73f096e0-495a-11e8-9f09-4053b9b25643.gif)


This PR should be used with the EmberOSF PR (https://github.com/CenterForOpenScience/ember-osf/pull/382)

## Ticket

https://openscience.atlassian.net/browse/IN-90

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
