### PR TITLE
[IN-202][Registries] Get registration types via API instead of list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `ember-route-action-helper` for route closure actions
 - COS version of eslint
+- Call to the store to get all registration types on discover page
 
 ### Changed
 - Update `osf-style` to use the latest version with navbar changes
+
+### Removed
+- Hard-coded list of search-facet-registration types
 
 ### Fixed
 - Syntax errors from updating to COS version of eslint

--- a/app/components/search-facet-registration-type.js
+++ b/app/components/search-facet-registration-type.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import $ from 'jquery';
 
 /**
@@ -24,6 +25,10 @@ import $ from 'jquery';
  * @class search-facet-registration-type
  */
 export default Component.extend({
+    store: service(),
+    toast: service(),
+    i18n: service(),
+
     registrationTypeCache: null,
     setVisibilityOfOSFFilters: computed('activeFilters.providers', function() {
         if (this.OSFIsSoleProvider()) {
@@ -43,16 +48,22 @@ export default Component.extend({
     }),
     init() {
         this._super(...arguments);
-        this.registrationTypes = [
-            'AsPredicted Preregistration',
-            'Election Research Preacceptance Competition',
-            'Open-Ended Registration',
-            'OSF-Standard Pre-Data Collection Registration',
-            'Prereg Challenge',
-            'Pre-Registration in Social Psychology (van \'t Veer & Giner-Sorolla, 2016): Pre-Registration',
-            'Replication Recipe (Brandt et al., 2013): Post-Completion',
-            'Replication Recipe (Brandt et al., 2013): Pre-Registration',
-        ];
+        this.get('store')
+            .findAll('metaschema')
+            .then(this._returnResults.bind(this))
+            .catch(this._errorMessage.bind(this));
+    },
+    _returnResults(results) {
+        const typeArr = [];
+        results.forEach(function(result) {
+            typeArr.push(result.get('name'));
+        });
+        typeArr.push('Election Research Preacceptance Competition');
+        typeArr.sort();
+        this.set('registrationTypes', typeArr);
+    },
+    _errorMessage() {
+        this.get('toast').error(this.get('i18n').t('discover.type_error'));
     },
     OSFIsSoleProvider() {
         let soleProvider = false;

--- a/app/components/search-facet-registration-type.js
+++ b/app/components/search-facet-registration-type.js
@@ -48,22 +48,26 @@ export default Component.extend({
     }),
     init() {
         this._super(...arguments);
-        this.get('store')
-            .findAll('metaschema')
+        this.get('store').query('metaschema', {
+            metaschemaType: 'registrations',
+            page: {
+                size: 100,
+            },
+        })
             .then(this._returnResults.bind(this))
             .catch(this._errorMessage.bind(this));
     },
     _returnResults(results) {
-        const typeArr = [];
-        results.forEach(function(result) {
-            typeArr.push(result.get('name'));
-        });
+        const typeArr = results.map(result => result.get('name'));
+        // Manually add 'Election Research Preacceptance Competition' to the list of possible
+        // facets. Metaschema was removed from the API as a possible registration type
+        // but should still be searchable
         typeArr.push('Election Research Preacceptance Competition');
         typeArr.sort();
         this.set('registrationTypes', typeArr);
     },
     _errorMessage() {
-        this.get('toast').error(this.get('i18n').t('discover.type_error'));
+        this.get('toast').error(this.get('i18n').t('discover.registration_metaschema_error'));
     },
     OSFIsSoleProvider() {
         let soleProvider = false;

--- a/app/components/search-facet-registration-type.js
+++ b/app/components/search-facet-registration-type.js
@@ -48,12 +48,7 @@ export default Component.extend({
     }),
     init() {
         this._super(...arguments);
-        this.get('store').query('metaschema', {
-            metaschemaType: 'registrations',
-            page: {
-                size: 100,
-            },
-        })
+        this.get('store').findAll('registration-metaschema')
             .then(this._returnResults.bind(this))
             .catch(this._errorMessage.bind(this));
     },

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -65,7 +65,7 @@ export default {
             },
             otherRepositories: 'Other registraation repositories',
         },
-        type_error: 'An error occurred getting registration types.  Please try again.',
+        registration_metaschema_error: 'An error occurred getting registration types. Please try again.',
     },
     index: {
         header: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -65,6 +65,7 @@ export default {
             },
             otherRepositories: 'Other registraation repositories',
         },
+        type_error: 'An error occurred getting registration types.  Please try again.',
     },
     index: {
         header: {

--- a/tests/integration/components/search-facet-registration-type-test.js
+++ b/tests/integration/components/search-facet-registration-type-test.js
@@ -3,12 +3,18 @@ import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('search-facet-registration-type', 'Integration | Component | search facet registration type', {
     integration: true,
+    beforeEach() {
+        this.inject.service('store', { as: 'store' });
+    },
 });
 
 test('it renders', function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
-
+    this.set('registrationTypes', [
+        'AsPredicted Preregistration',
+        'Election Research Preacceptance Competition',
+    ]);
     this.set('facet', { key: 'registration_type', title: 'OSF Registration Type', component: 'search-facet-registration-type' });
     this.set('key', 'registration_type');
     const noop = () => {};
@@ -22,6 +28,7 @@ test('it renders', function(assert) {
         updateFilters=(action noop)
         activeFilters=activeFilters
         filterReplace=filterReplace
+        registrationTypes=registrationTypes
     }}`);
 
     assert.equal(this.$('ul > li')[0].innerText.trim(), 'AsPredicted Preregistration');

--- a/tests/integration/components/search-facet-registration-type-test.js
+++ b/tests/integration/components/search-facet-registration-type-test.js
@@ -9,8 +9,6 @@ moduleForComponent('search-facet-registration-type', 'Integration | Component | 
 });
 
 test('it renders', function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.on('myAction', function(val) { ... });
     this.set('registrationTypes', [
         'AsPredicted Preregistration',
         'Election Research Preacceptance Competition',

--- a/tests/integration/components/search-facet-registration-type-test.js
+++ b/tests/integration/components/search-facet-registration-type-test.js
@@ -1,33 +1,44 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import EmberService from '@ember/service';
+import EmberObject from '@ember/object';
+import wait from 'ember-test-helpers/wait';
 import hbs from 'htmlbars-inline-precompile';
+
+const storeStub = EmberService.extend({
+    findAll() {
+        const results = [
+            EmberObject.create({ name: 'AsPredicted Preregistration' }),
+        ];
+        return Promise.resolve(results);
+    },
+});
 
 moduleForComponent('search-facet-registration-type', 'Integration | Component | search facet registration type', {
     integration: true,
+
     beforeEach() {
+        this.register('service:store', storeStub);
         this.inject.service('store', { as: 'store' });
+        this.set('facet', { key: 'registration_type', title: 'OSF Registration Type', component: 'search-facet-registration-type' });
+        this.set('key', 'registration_type');
+        const noop = () => {};
+        this.set('noop', noop);
+        this.set('activeFilters', { providers: [], types: [] });
+        this.set('filterReplace', { 'Open Science Framework': 'OSF' });
     },
 });
 
 test('it renders', function(assert) {
-    this.set('registrationTypes', [
-        'AsPredicted Preregistration',
-        'Election Research Preacceptance Competition',
-    ]);
-    this.set('facet', { key: 'registration_type', title: 'OSF Registration Type', component: 'search-facet-registration-type' });
-    this.set('key', 'registration_type');
-    const noop = () => {};
-    this.set('noop', noop);
-    this.set('activeFilters', { providers: [], types: [] });
-    this.set('filterReplace', { 'Open Science Framework': 'OSF' });
-
     this.render(hbs`{{search-facet-registration-type
         key=key
         options=facet
-        updateFilters=(action noop)
+        updateFilters=(action noop) 
         activeFilters=activeFilters
         filterReplace=filterReplace
-        registrationTypes=registrationTypes
     }}`);
 
-    assert.equal(this.$('ul > li')[0].innerText.trim(), 'AsPredicted Preregistration');
+    return wait()
+        .then(() => {
+            assert.equal(this.$('ul > li')[0].innerText.trim(), 'AsPredicted Preregistration');
+        });
 });


### PR DESCRIPTION
## Purpose

Some registration types aren't showing up on prod because they aren't included in the registration types list we have in the code.

## Summary of Changes

- Remove hard-coded list of registration types and replace it with a call to the store
- Manually add `Election Research Preacceptance Competition` to the list (has been removed as a possible type, but should still be filterable)
- Add translation to catch if getting types fails
- Fix test

## Side Effects / Testing Notes

This shouldn't affect how the front-end works or displays.  You should still be able to see all of the registration types in an alphabetical list.

![screen shot 2018-05-16 at 12 33 32 pm](https://user-images.githubusercontent.com/19379783/40130566-7122a02e-5905-11e8-9d91-bd04ec4320ac.png)

To be used with https://github.com/CenterForOpenScience/ember-osf/pull/389


## Ticket

https://openscience.atlassian.net/browse/IN-202

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
