### PR TITLE
[IN-36][Registries] Add unicode-byte-truncate for discover page sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- unicode-byte-truncate package
 
 ## [0.7.0] - 2018-05-01
 ### Added

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "eslint": "^4.4.1",
     "hint.css": "^2.5.0",
     "loader.js": "^4.2.3",
-    "postcss": "^5.1.0"
+    "postcss": "^5.1.0",
+    "unicode-byte-truncate": "1.0.0"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5945,7 +5945,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-integer@^1.0.4:
+is-integer@^1.0.4, is-integer@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-integer/-/is-integer-1.0.7.tgz#6bde81aacddf78b659b6629d629cadc51a886d5c"
   dependencies:
@@ -9782,6 +9782,17 @@ underscore.string@~3.3.4:
 underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+unicode-byte-truncate@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-byte-truncate/-/unicode-byte-truncate-1.0.0.tgz#aa6f0f3475193fe20c320ac9213e36e62e8764a7"
+  dependencies:
+    is-integer "^1.0.6"
+    unicode-substring "^0.1.0"
+
+unicode-substring@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-substring/-/unicode-substring-0.1.0.tgz#6120ce3c390385dbcd0f60c32b9065c4181d4b36"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Sharing icons needs  byte trunc.


## Summary of Changes
Add byte trunc


## Side Effects / Testing Notes
This PR will go out with registries 0.9.0 but there will be no testable changes until registries updates its emberosf version at a later date.


## Ticket

https://openscience.atlassian.net/browse/IN-36

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
