### PR TITLE
[IN-344][Registries] Add custom dimensions to Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - use of ember-osf `scheduled-banner` component
+- parameters for `authenticated`, `isPublic` and `resource` to pageView tracking
 
 ## [0.7.0] - 2018-05-01
 ### Added

--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,6 @@
 import EmberRouter from '@ember/routing/router';
 import { inject } from '@ember/service';
-import { scheduleOnce } from '@ember/runloop';
-import { get } from '@ember/object';
+import { run } from '@ember/runloop';
 import config from 'ember-get-config';
 
 const Router = EmberRouter.extend({
@@ -9,6 +8,7 @@ const Router = EmberRouter.extend({
     rootURL: config.rootURL,
     metrics: inject(),
     theme: inject(),
+    session: inject(),
 
     didTransition() {
         this._super(...arguments);
@@ -16,11 +16,31 @@ const Router = EmberRouter.extend({
     },
 
     _trackPage() {
-        scheduleOnce('afterRender', this, () => {
+        run.scheduleOnce('afterRender', this, () => {
+            // Tracks page with custom parameters
+            // authenticated => if the user is logged in or not
+            // isPublic      => if the resource the user is viewing is public or private.
+            //                  n/a is used for pages like discover and index
+            // page          => the name of the current page
+            // resource      => what resource the user is on. Ex node, preprint, registry.
+            // title         => the current route name
+
+            const {
+                authenticated,
+                isPublic,
+                resource,
+            } = config.metricsAdapters[0].dimensions;
             const page = document.location.pathname;
             const title = this.getWithDefault('currentRouteName', 'unknown');
+            const isAuthenticated = this.get('session.isAuthenticated');
 
-            get(this, 'metrics').trackPage({ page, title });
+            this.get('metrics').trackPage({
+                [authenticated]: isAuthenticated ? 'Logged in' : 'Logged out',
+                [isPublic]: 'n/a',
+                page,
+                [resource]: 'n/a',
+                title,
+            });
             this.set('theme.currentLocation', window.location.href);
         });
     },

--- a/config/environment.js
+++ b/config/environment.js
@@ -63,6 +63,11 @@ module.exports = function(environment) {
                 config: {
                     id: process.env.GOOGLE_ANALYTICS_ID,
                 },
+                dimensions: {
+                    authenticated: 'dimension1',
+                    resource: 'dimension2',
+                    isPublic: 'dimension3',
+                },
             },
             {
                 name: 'Keen',

--- a/tests/unit/controllers/forbidden-test.js
+++ b/tests/unit/controllers/forbidden-test.js
@@ -5,6 +5,7 @@ moduleFor('controller:forbidden', 'Unit | Controller | forbidden', {
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/controllers/page-not-found-test.js
+++ b/tests/unit/controllers/page-not-found-test.js
@@ -5,6 +5,7 @@ moduleFor('controller:page-not-found', 'Unit | Controller | page not found', {
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/controllers/provider-test.js
+++ b/tests/unit/controllers/provider-test.js
@@ -5,6 +5,7 @@ moduleFor('controller:provider', 'Unit | Controller | provider', {
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/routes/discover-test.js
+++ b/tests/unit/routes/discover-test.js
@@ -5,6 +5,7 @@ moduleFor('route:discover', 'Unit | Route | discover', {
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/routes/forbidden-test.js
+++ b/tests/unit/routes/forbidden-test.js
@@ -5,6 +5,7 @@ moduleFor('route:forbidden', 'Unit | Route | forbidden', {
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -5,6 +5,7 @@ moduleFor('route:index', 'Unit | Route | index', {
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/routes/page-not-found-test.js
+++ b/tests/unit/routes/page-not-found-test.js
@@ -5,6 +5,7 @@ moduleFor('route:page-not-found', 'Unit | Route | page not found', {
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/routes/provider/discover-test.js
+++ b/tests/unit/routes/provider/discover-test.js
@@ -6,6 +6,7 @@ moduleFor('route:provider/discover', 'Unit | Route | provider/discover', {
         'route:discover',
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/routes/provider/index-test.js
+++ b/tests/unit/routes/provider/index-test.js
@@ -6,6 +6,7 @@ moduleFor('route:provider/index', 'Unit | Route | provider/index', {
         'route:index',
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 

--- a/tests/unit/routes/provider/page-not-found-test.js
+++ b/tests/unit/routes/provider/page-not-found-test.js
@@ -5,6 +5,7 @@ moduleFor('route:provider/page-not-found', 'Unit | Route | provider/page not fou
     needs: [
         'service:metrics',
         'service:theme',
+        'service:session',
     ],
 });
 


### PR DESCRIPTION
## Purpose

To add custom dimensions to `trackPage` function for Google Analytics.

## Summary of Changes

- Add `authorized`, `isPublic` and `resource` dimensions to `trackPage`

## Side Effects / Testing Notes

There isn't a detail page at the moment for registries, so the functionality is this:

authorized => [whether or not the user is logged in will be either true or false]
isPublic => [n/a]
resource => [n/a]

When submit and detail pages get added to registries, then more cases can be added to the function.

## Ticket

https://openscience.atlassian.net/browse/IN-344

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
