### PR TITLE
[IN-338][Registries] GA anonymize sender ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### [0.7.1] -
+- `anonymizeIp: true` in GA config to anonymize sender IP.
 
 ## [0.7.0] - 2018-05-01
 ### Added

--- a/config/environment.js
+++ b/config/environment.js
@@ -62,6 +62,10 @@ module.exports = function(environment) {
                 environments: [process.env.KEEN_ENVIRONMENT] || ['production'],
                 config: {
                     id: process.env.GOOGLE_ANALYTICS_ID,
+                    setFields: {
+                        // Ensure the IP address of the sender will be anonymized.
+                        anonymizeIp: true,
+                    },
                 },
             },
             {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-i18n": "5.0.2",
     "ember-link-action": "^0.0.36",
     "ember-load-initializers": "^1.0.0",
+    "ember-metrics": "https://github.com/cos-forks/ember-metrics#v0.12.1+cos0",
     "ember-moment": "^7.4.1",
     "ember-page-title": "^3.2.2",
     "ember-resolver": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,9 +2268,9 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -3697,8 +3697,8 @@ ember-compatibility-helpers@^0.1.0, ember-compatibility-helpers@^0.1.1, ember-co
     semver "^5.4.1"
 
 ember-component-css@^0.6.0:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/ember-component-css/-/ember-component-css-0.6.3.tgz#7e6bc5c02875ceac87250cdf43eaa1872da7a7b4"
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/ember-component-css/-/ember-component-css-0.6.4.tgz#147ad1cf586ed5d2e5707d5406676273eea5897a"
   dependencies:
     broccoli-concat "^3.2.2"
     broccoli-funnel "^2.0.1"
@@ -3935,9 +3935,9 @@ ember-maybe-in-element@^0.1.3:
   dependencies:
     ember-cli-babel "^6.11.0"
 
-ember-metrics@^0.12.1:
+ember-metrics@^0.12.1, "ember-metrics@https://github.com/cos-forks/ember-metrics#v0.12.1+cos0":
   version "0.12.1"
-  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.12.1.tgz#8659343bf7b8bda403e70d482ff59cc9714d89f6"
+  resolved "https://github.com/cos-forks/ember-metrics#32fcc6eec0c4bc1974c854435401f94f660c6e74"
   dependencies:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"
@@ -7999,12 +7999,12 @@ postcss@^5.1.0, postcss@^5.2.16:
     supports-color "^3.2.3"
 
 postcss@^6.0.14, postcss@^6.0.19, postcss@^6.0.21:
-  version "6.0.21"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.21.tgz#8265662694eddf9e9a5960db6da33c39e4cd069d"
+  version "6.0.22"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
   dependencies:
-    chalk "^2.3.2"
+    chalk "^2.4.1"
     source-map "^0.6.1"
-    supports-color "^5.3.0"
+    supports-color "^5.4.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -9439,9 +9439,9 @@ supports-color@^5.1.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+supports-color@^5.3.0, supports-color@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
## Purpose

as part of GDPR compliance efforts, `anonymizeIp: true` allows
the sender IPs to be anonymized.

## Summary of Changes

- Update config to set `anonymizeIp: true`
- Point to fork to allow setting GA configs.

## Side Effects / Testing Notes
In case GA is enabled on staging environments, you can verify this flag is set by looking at the GA requests in the console (filter by `collect`)

## Ticket

[IN-338](https://openscience.atlassian.net/browse/IN-338)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`
