### PR TITLE
[IN-350][Registries] Fix discover regressions

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -150,6 +150,13 @@ export default Controller.extend(Analytics, discoverQueryParams.Mixin, {
             this.set('page', 1);
         }
 
+        if (changed.provider) {
+            // can only filter by type if OSF Regsitries is the only provider selected
+            if (queryParams.provider.length !== 1 || !queryParams.provider.includes('OSF')) {
+                this.resetQueryParams(['type']);
+            }
+        }
+
         if (changed.q) {
             this.get('trackDebouncedSearch').perform();
         }

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -134,7 +134,7 @@ export default Controller.extend(Analytics, discoverQueryParams.Mixin, {
 
     actions: {
         clearFilters() {
-            this.resetQueryParams();
+            this.resetQueryParams(Object.keys(filterQueryParams));
         },
         search() {
             this.get('fetchData').perform(this.get('allQueryParams'));


### PR DESCRIPTION
## Purpose
Fix discover regressions.
* Clicking "Clear filters" on the discover page should not remove your search terms.
* Xing out of the OSF Registries filter should also remove the OSF Registration Type filters.
(OSF Registration type filters also should also be removed if another provider is selected)

## Summary of Changes/Side Effects
* Clear filters" only clears filter query params
* Clear type filter if anything other than "OSF Registries" is selected as the provider

## Testing Notes
Should make sure that clear filters doesn't clear q, size, or sort but does clear all others.

Should also make sure the the type filter is cleared when anything other than "OSF Registries" is selected as the provider.

## Ticket

https://openscience.atlassian.net/browse/IN-350

## Notes for Reviewer
Clear filter thing was also changed on preprints - https://github.com/CenterForOpenScience/ember-osf-preprints/pull/599


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
